### PR TITLE
Fix typings for latest Deno

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -29,7 +29,7 @@ function doIt (options: IOptions, sayAloud: boolean): string {
 	var face = faces(options);
 	face.thoughts = sayAloud ? "\\" : "o";
 
-	var action = sayAloud ? "say" : "think";
+	var action: "say" | "think" = sayAloud ? "say" : "think";
 
-	return baloon[action](options.text, options.wrap ? options.wrapLength : null) + "\n" + cow(face);
+	return baloon[action](options.text, options.wrap ? options.wrapLength : undefined) + "\n" + cow(face);
 }

--- a/src/balloon.ts
+++ b/src/balloon.ts
@@ -1,4 +1,4 @@
-export const say = function (text: string, wrap: number): string {
+export const say = function (text: string, wrap?: number): string {
 	let delimiters = {
 		first : ["/", "\\"],
 		middle : ["|", "|"],
@@ -6,10 +6,10 @@ export const say = function (text: string, wrap: number): string {
 		only : ["<", ">"]
 	};
 
-	return format(text, wrap, delimiters);
+	return format(text, delimiters, wrap);
 }
 
-export const think = function (text: string, wrap: number): string {
+export const think = function (text: string, wrap?: number): string {
 	var delimiters = {
 		first : ["(", ")"],
 		middle : ["(", ")"],
@@ -17,10 +17,10 @@ export const think = function (text: string, wrap: number): string {
 		only : ["(", ")"]
 	};
 
-	return format(text, wrap, delimiters);
+	return format(text, delimiters, wrap);
 }
 
-function format (text: string, wrap: number, delimiters: any): string {
+function format (text: string, delimiters: any, wrap?: number): string {
 	var lines = split(text, wrap);
 	var maxLength = max(lines);
 

--- a/src/cows.ts
+++ b/src/cows.ts
@@ -1,9 +1,10 @@
 import replacer from './replacer.ts'
 import * as cows from './cows/cows.ts'
+import { IOptions } from './models/IOptions.ts';
 
 export const get = function (cow: string) {
-	let text = cows[cow]
-	return function (options) {
+	let text = (cows as Record<string, string>)[cow]
+	return function (options: IOptions) {
 		return replacer(text, options);
 	};
 }

--- a/src/faces.ts
+++ b/src/faces.ts
@@ -1,3 +1,5 @@
+import { IOptions } from './models/IOptions.ts';
+
 let modes = [
 	{
 		eyes: "oo",
@@ -37,7 +39,7 @@ let modes = [
 	}
 ];
 
-export const faces = function (options): any {
+export const faces = function (options: IOptions): any {
 	if (options.mode) {
 		let m = modes[options.mode]
 		return m;


### PR DESCRIPTION
cowsay is broken on Deno v0.40.0, seems like Deno added some stricter TypeScript settings.

This PR fixes cowsay so it runs without type errors on Deno v0.40.0 (current version at the time of writing).